### PR TITLE
ASM-4039 Some switches need carriage return instead of just newline

### DIFF
--- a/lib/puppet/cmc/transport.rb
+++ b/lib/puppet/cmc/transport.rb
@@ -57,6 +57,12 @@ module Puppet
           retry
         end
       end
+
+      #We overwrite Puppet's method here because some switches require a \r as well to work
+      def send(line)
+        Puppet.debug("ssh: send #{line}") if @verbose
+        @channel.send_data(line + "\n\r")
+      end
     end
   end
 end


### PR DESCRIPTION
Also, some of the code that was checking if an Enable password had been set was in the incorrect place after previous refactoring