### PR TITLE
ASM-7030 Support stash onboarding

### DIFF
--- a/lib/puppet/type/chassis_settings.rb
+++ b/lib/puppet/type/chassis_settings.rb
@@ -141,4 +141,8 @@
     desc ""
   end
 
+  newproperty(:stash_mode) do
+    newvalues("dual", "single", "joined")
+  end
+
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -31,9 +31,7 @@ define cmc::config(
   $port     = '22',
   $target   = "${settings::confdir}/defice/${name}.conf"
   ) {
-  
   include cmc::params
-  
   $owner = $cmc::params::owner
   $group = $cmc::params::group
   $mode  = $cmc::params::mode


### PR DESCRIPTION
Added support for configuring stash storage during FX2 chassis configuration. Supported modes are dual. single and joined. We need to keep the chassis in dual mode for supporting current all-flash FX2 configuration