### PR TITLE
[DNM] ASM-7880 Properly handle SSH connection failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group(:development, :test) do
   # versions matching ~> 0.10.5 are supported. All other versions are unsupported
   # and can be expected to fail.
   gem "mocha", "~> 0.10.5", :require => false
-
+  gem 'json_pure', '2.0.1' # pin this puppet dependency to 1.9-compat version
   gem "yarjuf", "~> 1.0"
 end
 


### PR DESCRIPTION
We found that often when the connection was closed prematurely,
 subsequent connection attemps with throwing exceptions such as: Errno::ECONNREFUSED.
Added a catch-all rescue to re-attempt the connection for 4 times, sleeping 30 seconds
between each retry