### PR TITLE
ESTS-140275 "Changed rake and rspec-puppet versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ end
 #gem "puppet", :path => File.dirname(__FILE__), :require => false
 gem "facter", *location_for(ENV['FACTER_LOCATION'] || '~> 1.6')
 gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '~> 1.0')
-gem "rake", :require => false
+gem "rake", '<11.0', :require => false
 gem "rgen", "0.6.5", :require => false
 
 
@@ -32,7 +32,7 @@ group(:development, :test) do
   # Jenkins workers may be using RSpec 2.9, so RSpec 2.11 syntax
   # (like `expect(value).to eq matcher`) should be avoided.
   gem "rspec", "~> 2.11.0", :require => false
-  gem "rspec-puppet"
+  gem "rspec-puppet", "2.4.0"
   # Mocha is not compatible across minor version changes; because of this only
   # versions matching ~> 0.10.5 are supported. All other versions are unsupported
   # and can be expected to fail.


### PR DESCRIPTION
Previously rake command is failing due to error undefined method `last_comment which was removed 
 in rake version 11.0. it also has issue with register_listener for rspec-puppet, downgrading the version solved this issue.

 This PR changes the versions as a work around for the issue with rspec-puppet and rake version 11.0